### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Code Self Study",
   "short_name": "codeselfstudy",
   "description": "A browser extension for Code Self Study (codeselfstudy.com)",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "icons": {
     "64": "icons/icon.png"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeselfstudy/codeselfstudy_browser_extension",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "A browser extension for Code Self Study",
   "main": "background_script.js",
   "scripts": {


### PR DESCRIPTION
Bump the extension version 0.9.1 → 0.10.0 (minor) for the Manifest V3 migration release.

- `manifest.json` version → 0.10.0
- `package.json` version → 0.10.0

`web-ext build` now emits `code_self_study-0.10.0.zip` for both browsers. Tag `v0.10.0` accompanies this release.