### PR TITLE
Add UI mockups: SaaS, terminal, brutalist (popup + options)

### DIFF
--- a/mockups/01-saas.html
+++ b/mockups/01-saas.html
@@ -1,0 +1,998 @@
+<!doctype html>
+<html lang="en" data-theme="light" data-palette="indigo" data-font="sans">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>01 · Modern SaaS — Code Self Study mockup</title>
+    <style>
+      /* ---- Palettes: all 7 contract vars, light AND dark ---- */
+      [data-palette="indigo"] {
+        --c-bg: #f5f6fb;
+        --c-surface: #ffffff;
+        --c-text: #1b1e2e;
+        --c-muted: #6a7186;
+        --c-accent: #4f46e5;
+        --c-on-accent: #ffffff;
+        --c-border: #e6e8f2;
+      }
+      [data-palette="indigo"][data-theme="dark"] {
+        --c-bg: #0e1017;
+        --c-surface: #171a24;
+        --c-text: #e9ebf6;
+        --c-muted: #9aa1b4;
+        --c-accent: #8b87ff;
+        --c-on-accent: #0b0d14;
+        --c-border: #262a38;
+      }
+      [data-palette="emerald"] {
+        --c-bg: #f3f8f5;
+        --c-surface: #ffffff;
+        --c-text: #14231c;
+        --c-muted: #5f7369;
+        --c-accent: #0d9f6e;
+        --c-on-accent: #ffffff;
+        --c-border: #dcebe3;
+      }
+      [data-palette="emerald"][data-theme="dark"] {
+        --c-bg: #0a130f;
+        --c-surface: #12201a;
+        --c-text: #e4f1ea;
+        --c-muted: #8fa89b;
+        --c-accent: #34d399;
+        --c-on-accent: #06120c;
+        --c-border: #1e3128;
+      }
+      [data-palette="slate"] {
+        --c-bg: #f4f6f8;
+        --c-surface: #ffffff;
+        --c-text: #172029;
+        --c-muted: #64748b;
+        --c-accent: #2563eb;
+        --c-on-accent: #ffffff;
+        --c-border: #e2e8f0;
+      }
+      [data-palette="slate"][data-theme="dark"] {
+        --c-bg: #0d1219;
+        --c-surface: #151c26;
+        --c-text: #e6ecf3;
+        --c-muted: #94a3b8;
+        --c-accent: #6ea8fe;
+        --c-on-accent: #0a0f16;
+        --c-border: #253040;
+      }
+
+      /* ---- Component CSS: contract variables only ---- */
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--c-bg);
+        color: var(--c-text);
+        font-family: var(--font-body);
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      .stage {
+        display: flex;
+        flex-wrap: wrap;
+        gap: calc(var(--density) * 32px);
+        align-items: flex-start;
+        justify-content: center;
+        padding: calc(var(--density) * 40px) 20px 120px;
+        max-width: 900px;
+        margin: 0 auto;
+      }
+      .surface {
+        display: flex;
+        flex-direction: column;
+        gap: calc(var(--density) * 10px);
+      }
+      .surface-label {
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--c-muted);
+        font-family: var(--font-heading);
+      }
+
+      /* Popup */
+      .popup {
+        width: 320px;
+        background: var(--c-surface);
+        border: 1px solid var(--c-border);
+        border-radius: calc(var(--radius) + 6px);
+        box-shadow: 0 18px 40px -20px rgba(15, 20, 40, 0.45);
+        overflow: hidden;
+      }
+      .popup-head {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: calc(var(--density) * 16px);
+        border-bottom: 1px solid var(--c-border);
+      }
+      .logo {
+        display: grid;
+        place-items: center;
+        width: 30px;
+        height: 30px;
+        border-radius: calc(var(--radius) * 0.7 + 2px);
+        background: var(--c-accent);
+        color: var(--c-on-accent);
+        flex: none;
+      }
+      .logo svg {
+        width: 17px;
+        height: 17px;
+      }
+      .popup-head h1 {
+        font-family: var(--font-heading);
+        font-size: 15px;
+        margin: 0;
+        font-weight: 650;
+      }
+      .popup-head p {
+        margin: 1px 0 0;
+        font-size: 11.5px;
+        color: var(--c-muted);
+      }
+      .popup-body {
+        padding: calc(var(--density) * 16px);
+        display: grid;
+        gap: calc(var(--density) * 14px);
+      }
+      .btn-primary {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        width: 100%;
+        border: 0;
+        cursor: pointer;
+        padding: calc(var(--density) * 11px) 14px;
+        border-radius: var(--radius);
+        background: var(--c-accent);
+        color: var(--c-on-accent);
+        font-family: var(--font-heading);
+        font-size: 14px;
+        font-weight: 600;
+        box-shadow: 0 8px 18px -10px var(--c-accent);
+        transition: transform 0.05s ease;
+      }
+      .btn-primary:hover {
+        filter: brightness(1.05);
+      }
+      .btn-primary:active {
+        transform: translateY(1px);
+      }
+      .btn-primary svg {
+        width: 16px;
+        height: 16px;
+      }
+      .links {
+        display: grid;
+        gap: calc(var(--density) * 6px);
+      }
+      .link {
+        display: flex;
+        align-items: center;
+        gap: 11px;
+        text-decoration: none;
+        color: inherit;
+        padding: calc(var(--density) * 9px) 10px;
+        border-radius: var(--radius);
+        border: 1px solid transparent;
+      }
+      .link:hover {
+        background: var(--c-bg);
+        border-color: var(--c-border);
+      }
+      .link .ico {
+        display: grid;
+        place-items: center;
+        width: 30px;
+        height: 30px;
+        border-radius: calc(var(--radius) * 0.7 + 2px);
+        background: var(--c-bg);
+        border: 1px solid var(--c-border);
+        color: var(--c-accent);
+        flex: none;
+      }
+      .link .ico svg {
+        width: 16px;
+        height: 16px;
+      }
+      .link .txt {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+      }
+      .link .txt b {
+        font-weight: 600;
+        font-size: 13.5px;
+      }
+      .link .txt span {
+        font-size: 11px;
+        color: var(--c-muted);
+      }
+      .link .chev {
+        margin-left: auto;
+        color: var(--c-muted);
+        opacity: 0.6;
+      }
+      .popup-foot {
+        padding: 10px 16px;
+        border-top: 1px solid var(--c-border);
+        font-size: 11px;
+        color: var(--c-muted);
+        display: flex;
+        justify-content: space-between;
+      }
+
+      /* Options */
+      .options {
+        width: 440px;
+        max-width: 100%;
+        display: grid;
+        gap: calc(var(--density) * 16px);
+      }
+      .options-head h1 {
+        font-family: var(--font-heading);
+        font-size: 22px;
+        margin: 0;
+      }
+      .options-head p {
+        margin: 2px 0 0;
+        color: var(--c-muted);
+        font-size: 13px;
+      }
+      .card {
+        background: var(--c-surface);
+        border: 1px solid var(--c-border);
+        border-radius: calc(var(--radius) + 4px);
+        padding: calc(var(--density) * 18px);
+        box-shadow: 0 12px 30px -24px rgba(15, 20, 40, 0.5);
+      }
+      .card h2 {
+        font-family: var(--font-heading);
+        font-size: 13px;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: var(--c-muted);
+        margin: 0 0 calc(var(--density) * 14px);
+      }
+      .field {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: calc(var(--density) * 10px) 0;
+        border-top: 1px solid var(--c-border);
+      }
+      .field:first-of-type {
+        border-top: 0;
+      }
+      .field label,
+      .field .flabel {
+        font-size: 13.5px;
+      }
+      .field .fhint {
+        display: block;
+        font-size: 11.5px;
+        color: var(--c-muted);
+        margin-top: 2px;
+      }
+      select {
+        font: inherit;
+        font-size: 13px;
+        color: var(--c-text);
+        background: var(--c-bg);
+        border: 1px solid var(--c-border);
+        border-radius: var(--radius);
+        padding: 7px 10px;
+      }
+      .switch {
+        position: relative;
+        width: 40px;
+        height: 23px;
+        flex: none;
+      }
+      .switch input {
+        position: absolute;
+        opacity: 0;
+      }
+      .switch .track {
+        position: absolute;
+        inset: 0;
+        background: var(--c-border);
+        border-radius: 999px;
+        transition: background 0.15s ease;
+      }
+      .switch .track::after {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        width: 17px;
+        height: 17px;
+        border-radius: 50%;
+        background: var(--c-surface);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+        transition: transform 0.15s ease;
+      }
+      .switch input:checked + .track {
+        background: var(--c-accent);
+      }
+      .switch input:checked + .track::after {
+        transform: translateX(17px);
+      }
+      .about p {
+        margin: 0 0 10px;
+        font-size: 13.5px;
+        color: var(--c-text);
+      }
+      .about .about-links {
+        list-style: none;
+        margin: 0 0 12px;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .about .about-links a {
+        font-size: 12.5px;
+        color: var(--c-accent);
+        text-decoration: none;
+        border: 1px solid var(--c-border);
+        border-radius: 999px;
+        padding: 4px 11px;
+      }
+      .about .about-links a:hover {
+        border-color: var(--c-accent);
+      }
+      .about .ver {
+        font-size: 12px;
+        color: var(--c-muted);
+        margin: 0;
+      }
+
+      .design-notes {
+        max-width: 780px;
+        margin: 0 auto 40px;
+        color: var(--c-muted);
+        font-size: 13px;
+      }
+      .design-notes summary {
+        cursor: pointer;
+        color: var(--c-text);
+        font-family: var(--font-heading);
+      }
+      .design-notes p {
+        margin: 10px 0 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="stage">
+      <!-- Popup surface -->
+      <div class="surface">
+        <div class="surface-label">Toolbar popup · 320px</div>
+        <div class="popup">
+          <div class="popup-head">
+            <span class="logo">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+                <path d="M16 3h3a2 2 0 0 1 2 2v3" />
+                <path d="M8 21H5a2 2 0 0 1-2-2v-3" />
+                <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+                <path d="M9 12h6" />
+                <path d="M12 9v6" />
+              </svg>
+            </span>
+            <div>
+              <h1>Code Self Study</h1>
+              <p>Share to the community forum</p>
+            </div>
+          </div>
+          <div class="popup-body">
+            <button class="btn-primary">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+                <path d="M12 3v13" />
+                <path d="m7 8 5-5 5 5" />
+              </svg>
+              Share Current Page
+            </button>
+            <nav class="links">
+              <a class="link" href="#">
+                <span class="ico"
+                  ><svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path
+                      d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+                    /></svg
+                ></span>
+                <span class="txt"
+                  ><b>Coding Forum</b><span>forum.codeselfstudy.com</span></span
+                >
+                <span class="chev">›</span>
+              </a>
+              <a class="link" href="#">
+                <span class="ico"
+                  ><svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0 1 18 0z" />
+                    <circle cx="12" cy="10" r="3" /></svg
+                ></span>
+                <span class="txt"
+                  ><b>SF Bay Meetups</b
+                  ><span>meetup.com/codeselfstudy</span></span
+                >
+                <span class="chev">›</span>
+              </a>
+              <a class="link" href="#">
+                <span class="ico"
+                  ><svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <line x1="4" y1="9" x2="20" y2="9" />
+                    <line x1="4" y1="15" x2="20" y2="15" />
+                    <line x1="10" y1="3" x2="8" y2="21" />
+                    <line x1="16" y1="3" x2="14" y2="21" /></svg
+                ></span>
+                <span class="txt"
+                  ><b>Programming Chatroom</b
+                  ><span>codeselfstudy.slack.com</span></span
+                >
+                <span class="chev">›</span>
+              </a>
+            </nav>
+          </div>
+          <div class="popup-foot">
+            <span>Code Self Study</span>
+            <span>v0.11.0</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Options surface -->
+      <div class="surface">
+        <div class="surface-label">Options page</div>
+        <div class="options">
+          <div class="options-head">
+            <h1>Code Self Study</h1>
+            <p>Extension options</p>
+          </div>
+          <section class="card">
+            <h2>Sharing</h2>
+            <div class="field">
+              <label for="cat">Default forum category</label>
+              <select id="cat">
+                <option>General Discussion</option>
+                <option>Help &amp; Support</option>
+                <option>Show &amp; Tell</option>
+                <option>Resources</option>
+              </select>
+            </div>
+            <div class="field">
+              <span class="flabel"
+                >Include selected text as a quote
+                <span class="fhint"
+                  >Wraps your selection as a markdown blockquote</span
+                >
+              </span>
+              <label class="switch"
+                ><input type="checkbox" checked /><span class="track"></span
+              ></label>
+            </div>
+            <div class="field">
+              <span class="flabel">Open the forum in a new tab</span>
+              <label class="switch"
+                ><input type="checkbox" checked /><span class="track"></span
+              ></label>
+            </div>
+          </section>
+          <section class="card about">
+            <h2>About</h2>
+            <p>
+              One-click sharing of the page you're viewing to the Code Self
+              Study Discourse forum, plus quick links to the group's resources.
+            </p>
+            <ul class="about-links">
+              <li><a href="#">Coding Forum</a></li>
+              <li><a href="#">SF Bay Meetups</a></li>
+              <li><a href="#">Programming Chatroom</a></li>
+            </ul>
+            <p class="ver">Version 0.11.0 · MIT License</p>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <details class="design-notes">
+      <summary>Design notes — 01 · Modern SaaS</summary>
+      <p>
+        <strong>Direction:</strong> a clean, friendly product UI — rounded
+        cards, a soft accent-colored primary action, generous spacing, and
+        subtle elevation. The popup reads as a focused action sheet; the options
+        page as a settings panel.
+      </p>
+      <p>
+        <strong>Typography:</strong> a neutral system sans for body with the
+        same family for headings at heavier weights — invisible, legible, gets
+        out of the way. A rounded system stack is offered as an alternate for a
+        softer feel.
+      </p>
+      <p>
+        <strong>Palettes:</strong> Indigo (default) is confident and modern;
+        Emerald leans calm/organic; Slate is the safe neutral. Each defines all
+        seven tokens for light and dark, so dark mode is a pure variable swap.
+      </p>
+    </details>
+
+    <!-- DP:STYLE -->
+    <style id="dp-style">
+      #design-panel {
+        --dp-bg: rgba(28, 30, 34, 0.92);
+        --dp-text: #e7e9ee;
+        --dp-muted: #9aa1ad;
+        --dp-line: rgba(255, 255, 255, 0.14);
+        --dp-active: #6ea8fe;
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        z-index: 99999;
+        width: 240px;
+        max-height: min(70vh, 560px);
+        overflow: auto;
+        background: var(--dp-bg);
+        color: var(--dp-text);
+        font:
+          12px/1.45 system-ui,
+          -apple-system,
+          "Segoe UI",
+          sans-serif;
+        border: 1px solid var(--dp-line);
+        border-radius: 10px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(6px);
+      }
+      #design-panel * {
+        box-sizing: border-box;
+        font: inherit;
+        color: inherit;
+      }
+      #design-panel header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--dp-line);
+      }
+      #design-panel header strong {
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      #dp-toggle {
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        padding: 2px 6px;
+        border-radius: 6px;
+        line-height: 1;
+      }
+      #dp-toggle:hover {
+        background: var(--dp-line);
+      }
+      #design-panel[data-collapsed="true"] {
+        width: auto;
+        max-height: none;
+        overflow: hidden;
+      }
+      #design-panel[data-collapsed="true"] #dp-body {
+        display: none;
+      }
+      #design-panel[data-collapsed="true"] header {
+        border-bottom: 0;
+      }
+      #dp-body {
+        padding: 10px 12px 12px;
+        display: grid;
+        gap: 12px;
+      }
+      #design-panel fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+      }
+      #design-panel legend {
+        padding: 0 0 6px;
+        color: var(--dp-muted);
+        text-transform: uppercase;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+      }
+      #design-panel .dp-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      #design-panel .dp-options label {
+        border: 1px solid var(--dp-line);
+        border-radius: 999px;
+        padding: 3px 10px;
+        cursor: pointer;
+        user-select: none;
+      }
+      #design-panel .dp-options input {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+      }
+      #design-panel .dp-options input:checked + span {
+        color: var(--dp-active);
+      }
+      #design-panel .dp-options label:has(input:checked) {
+        border-color: var(--dp-active);
+      }
+      #design-panel .dp-slider {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 8px;
+      }
+      #design-panel .dp-slider input[type="range"] {
+        width: 100%;
+        accent-color: var(--dp-active);
+      }
+      #design-panel .dp-slider output {
+        min-width: 42px;
+        text-align: right;
+        color: var(--dp-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      #dp-reset {
+        width: 100%;
+        border: 1px solid var(--dp-line);
+        background: transparent;
+        border-radius: 8px;
+        padding: 6px 0;
+        cursor: pointer;
+      }
+      #dp-reset:hover {
+        border-color: var(--dp-active);
+        color: var(--dp-active);
+      }
+    </style>
+    <!-- /DP:STYLE -->
+
+    <!-- DP:MARKUP -->
+    <aside
+      id="design-panel"
+      data-collapsed="false"
+      aria-label="Design control panel"
+    >
+      <header>
+        <strong>Design panel</strong>
+        <button
+          id="dp-toggle"
+          type="button"
+          aria-expanded="true"
+          title="Collapse panel"
+        >
+          −
+        </button>
+      </header>
+      <div id="dp-body">
+        <fieldset data-dp-group="mode">
+          <legend>Mode</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset data-dp-group="palette">
+          <legend>Palette</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset data-dp-group="font">
+          <legend>Font</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset>
+          <legend>Radius</legend>
+          <div class="dp-slider">
+            <input
+              type="range"
+              data-dp-range="radius"
+              min="0"
+              max="24"
+              step="1"
+            />
+            <output data-dp-out="radius"></output>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Density</legend>
+          <div class="dp-slider">
+            <input
+              type="range"
+              data-dp-range="density"
+              min="0.8"
+              max="1.3"
+              step="0.05"
+            />
+            <output data-dp-out="density"></output>
+          </div>
+        </fieldset>
+        <button id="dp-reset" type="button">Reset to defaults</button>
+      </div>
+    </aside>
+    <!-- /DP:MARKUP -->
+
+    <script>
+      window.DP_CONFIG = {
+        slug: "01-saas",
+        palettes: [
+          { id: "indigo", label: "Indigo" },
+          { id: "emerald", label: "Emerald" },
+          { id: "slate", label: "Slate" },
+        ],
+        fonts: [
+          {
+            id: "sans",
+            label: "Sans",
+            body: "system-ui, -apple-system, 'Segoe UI', sans-serif",
+            heading: "system-ui, -apple-system, 'Segoe UI', sans-serif",
+          },
+          {
+            id: "rounded",
+            label: "Rounded",
+            body: "ui-rounded, 'SF Pro Rounded', 'Segoe UI', system-ui, sans-serif",
+            heading:
+              "ui-rounded, 'SF Pro Rounded', 'Segoe UI', system-ui, sans-serif",
+          },
+        ],
+        defaults: {
+          mode: "light",
+          palette: "indigo",
+          font: "sans",
+          radius: 10,
+          density: 1,
+        },
+      };
+    </script>
+
+    <!-- DP:SCRIPT -->
+    <script id="dp-script">
+      (function () {
+        var config = window.DP_CONFIG;
+        if (
+          !config ||
+          !config.slug ||
+          !Array.isArray(config.palettes) ||
+          !Array.isArray(config.fonts)
+        ) {
+          console.error(
+            "design-panel: window.DP_CONFIG is missing or malformed"
+          );
+          return;
+        }
+        var KEY = "design-panel:" + config.slug;
+        var root = document.documentElement;
+        var panel = document.getElementById("design-panel");
+        var defaults = {
+          mode: config.defaults.mode === "dark" ? "dark" : "light",
+          palette: idOrFirst(config.palettes, config.defaults.palette),
+          font: idOrFirst(config.fonts, config.defaults.font),
+          radius: clamp(num(config.defaults.radius, 8), 0, 24),
+          density: clamp(num(config.defaults.density, 1), 0.8, 1.3),
+          collapsed: false,
+        };
+
+        function idOrFirst(list, id) {
+          for (var i = 0; i < list.length; i += 1) {
+            if (list[i].id === id) return id;
+          }
+          return list.length > 0 ? list[0].id : "";
+        }
+        function hasId(list, id) {
+          for (var i = 0; i < list.length; i += 1) {
+            if (list[i].id === id) return true;
+          }
+          return false;
+        }
+        function num(value, fallback) {
+          return typeof value === "number" && isFinite(value)
+            ? value
+            : fallback;
+        }
+        function clamp(value, min, max) {
+          return Math.min(max, Math.max(min, value));
+        }
+        function findFont(id) {
+          for (var i = 0; i < config.fonts.length; i += 1) {
+            if (config.fonts[i].id === id) return config.fonts[i];
+          }
+          return config.fonts[0];
+        }
+
+        function load() {
+          var state = {};
+          try {
+            state = JSON.parse(localStorage.getItem(KEY) || "{}") || {};
+          } catch (error) {
+            state = {};
+          }
+          return {
+            mode:
+              state.mode === "dark" || state.mode === "light"
+                ? state.mode
+                : defaults.mode,
+            palette: hasId(config.palettes, state.palette)
+              ? state.palette
+              : defaults.palette,
+            font: hasId(config.fonts, state.font) ? state.font : defaults.font,
+            radius: clamp(num(state.radius, defaults.radius), 0, 24),
+            density: clamp(num(state.density, defaults.density), 0.8, 1.3),
+            collapsed: state.collapsed === true,
+          };
+        }
+        function save() {
+          try {
+            localStorage.setItem(
+              KEY,
+              JSON.stringify(Object.assign({ v: 1 }, current))
+            );
+          } catch (error) {
+            /* storage unavailable (e.g. some file:// modes): live state still works */
+          }
+        }
+
+        var current = load();
+
+        function apply() {
+          root.setAttribute("data-theme", current.mode);
+          root.setAttribute("data-palette", current.palette);
+          root.setAttribute("data-font", current.font);
+          root.style.setProperty("--radius", current.radius + "px");
+          root.style.setProperty("--density", String(current.density));
+          var font = findFont(current.font);
+          root.style.setProperty("--font-body", font.body);
+          root.style.setProperty("--font-heading", font.heading || font.body);
+          panel.setAttribute("data-collapsed", String(current.collapsed));
+          var toggle = document.getElementById("dp-toggle");
+          toggle.textContent = current.collapsed ? "✦" : "−";
+          toggle.setAttribute("aria-expanded", String(!current.collapsed));
+          toggle.setAttribute(
+            "title",
+            current.collapsed ? "Expand panel" : "Collapse panel"
+          );
+          syncControls();
+        }
+
+        function radioGroup(group, options, getValue) {
+          var container = panel.querySelector(
+            '[data-dp-group="' + group + '"] .dp-options'
+          );
+          options.forEach(function (option) {
+            var label = document.createElement("label");
+            var input = document.createElement("input");
+            input.type = "radio";
+            input.name = "dp-" + group + "-" + config.slug;
+            input.setAttribute("value", option.id);
+            input.addEventListener("change", function () {
+              current[group] = option.id;
+              save();
+              apply();
+            });
+            var text = document.createElement("span");
+            text.textContent = option.label;
+            label.appendChild(input);
+            label.appendChild(text);
+            container.appendChild(label);
+          });
+        }
+
+        function syncControls() {
+          ["mode", "palette", "font"].forEach(function (group) {
+            var inputs = panel.querySelectorAll(
+              '[data-dp-group="' + group + '"] input'
+            );
+            inputs.forEach(function (input) {
+              input.checked = input.value === current[group];
+            });
+          });
+          var radius = panel.querySelector('[data-dp-range="radius"]');
+          var density = panel.querySelector('[data-dp-range="density"]');
+          radius.value = String(current.radius);
+          density.value = String(current.density);
+          panel.querySelector('[data-dp-out="radius"]').textContent =
+            current.radius + "px";
+          panel.querySelector('[data-dp-out="density"]').textContent =
+            "×" + current.density.toFixed(2);
+        }
+
+        radioGroup("mode", [
+          { id: "light", label: "Light" },
+          { id: "dark", label: "Dark" },
+        ]);
+        radioGroup("palette", config.palettes);
+        radioGroup("font", config.fonts);
+
+        panel
+          .querySelector('[data-dp-range="radius"]')
+          .addEventListener("input", function (event) {
+            current.radius = clamp(
+              num(Number(event.target.value), defaults.radius),
+              0,
+              24
+            );
+            save();
+            apply();
+          });
+        panel
+          .querySelector('[data-dp-range="density"]')
+          .addEventListener("input", function (event) {
+            current.density = clamp(
+              num(Number(event.target.value), defaults.density),
+              0.8,
+              1.3
+            );
+            save();
+            apply();
+          });
+        document
+          .getElementById("dp-toggle")
+          .addEventListener("click", function () {
+            current.collapsed = !current.collapsed;
+            save();
+            apply();
+          });
+        document
+          .getElementById("dp-reset")
+          .addEventListener("click", function () {
+            try {
+              localStorage.removeItem(KEY);
+            } catch (error) {
+              /* ignore */
+            }
+            current = load();
+            apply();
+          });
+
+        apply();
+      })();
+    </script>
+    <!-- /DP:SCRIPT -->
+  </body>
+</html>

--- a/mockups/02-terminal.html
+++ b/mockups/02-terminal.html
@@ -1,0 +1,952 @@
+<!doctype html>
+<html lang="en" data-theme="dark" data-palette="phosphor" data-font="mono">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>02 · Terminal — Code Self Study mockup</title>
+    <style>
+      /* ---- Palettes: all 7 contract vars, light AND dark ---- */
+      [data-palette="phosphor"] {
+        --c-bg: #eef3ee;
+        --c-surface: #ffffff;
+        --c-text: #143d1c;
+        --c-muted: #4e7357;
+        --c-accent: #1a9e2e;
+        --c-on-accent: #ffffff;
+        --c-border: #cfe0d3;
+      }
+      [data-palette="phosphor"][data-theme="dark"] {
+        --c-bg: #0a0f0b;
+        --c-surface: #0f150f;
+        --c-text: #b8f5c0;
+        --c-muted: #5f8f68;
+        --c-accent: #41ff00;
+        --c-on-accent: #06120a;
+        --c-border: #1d2c1f;
+      }
+      [data-palette="amber"] {
+        --c-bg: #f5f0e6;
+        --c-surface: #fffdf7;
+        --c-text: #4a3410;
+        --c-muted: #7a6535;
+        --c-accent: #b8730a;
+        --c-on-accent: #ffffff;
+        --c-border: #e6dcc4;
+      }
+      [data-palette="amber"][data-theme="dark"] {
+        --c-bg: #0f0b04;
+        --c-surface: #17110a;
+        --c-text: #ffd38a;
+        --c-muted: #a07b45;
+        --c-accent: #ffb000;
+        --c-on-accent: #1a1206;
+        --c-border: #2c2110;
+      }
+      [data-palette="ice"] {
+        --c-bg: #eef5f7;
+        --c-surface: #ffffff;
+        --c-text: #0e343d;
+        --c-muted: #4c7580;
+        --c-accent: #0a94ad;
+        --c-on-accent: #ffffff;
+        --c-border: #cbe2e8;
+      }
+      [data-palette="ice"][data-theme="dark"] {
+        --c-bg: #060f12;
+        --c-surface: #0b171b;
+        --c-text: #b3ecf5;
+        --c-muted: #5b8b95;
+        --c-accent: #22d3ee;
+        --c-on-accent: #04141a;
+        --c-border: #143038;
+      }
+
+      /* ---- Component CSS: contract variables only ---- */
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--c-bg);
+        color: var(--c-text);
+        font-family: var(--font-body);
+        line-height: 1.5;
+      }
+      /* subtle CRT scanline, tinted from the text color so it themes cleanly */
+      body::after {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        background: repeating-linear-gradient(
+          to bottom,
+          transparent 0 2px,
+          color-mix(in srgb, var(--c-text) 5%, transparent) 2px 3px
+        );
+        opacity: 0.5;
+        z-index: 1;
+      }
+      .stage {
+        position: relative;
+        z-index: 2;
+        display: flex;
+        flex-wrap: wrap;
+        gap: calc(var(--density) * 30px);
+        align-items: flex-start;
+        justify-content: center;
+        padding: calc(var(--density) * 40px) 20px 120px;
+        max-width: 920px;
+        margin: 0 auto;
+      }
+      .surface {
+        display: flex;
+        flex-direction: column;
+        gap: calc(var(--density) * 10px);
+      }
+      .surface-label {
+        font-size: 12px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--c-muted);
+      }
+      .surface-label::before {
+        content: "// ";
+      }
+
+      /* terminal window chrome */
+      .win {
+        background: var(--c-surface);
+        border: 1px solid var(--c-border);
+        border-radius: var(--radius);
+        overflow: hidden;
+        box-shadow: 0 0 0 1px
+          color-mix(in srgb, var(--c-accent) 12%, transparent);
+      }
+      .win-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: calc(var(--density) * 9px) 12px;
+        border-bottom: 1px solid var(--c-border);
+        background: color-mix(in srgb, var(--c-text) 5%, transparent);
+      }
+      .dots {
+        display: flex;
+        gap: 6px;
+      }
+      .dots i {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--c-border);
+        display: inline-block;
+      }
+      .win-bar b {
+        font-size: 12px;
+        color: var(--c-muted);
+        font-weight: 500;
+      }
+      .prompt {
+        color: var(--c-accent);
+      }
+
+      /* Popup */
+      .popup {
+        width: 340px;
+      }
+      .win-body {
+        padding: calc(var(--density) * 15px);
+        display: grid;
+        gap: calc(var(--density) * 13px);
+        font-size: 13px;
+      }
+      .banner {
+        color: var(--c-accent);
+        white-space: pre;
+        font-size: 11px;
+        line-height: 1.25;
+        margin: 0;
+        text-shadow: 0 0 8px
+          color-mix(in srgb, var(--c-accent) 45%, transparent);
+      }
+      .cmd-btn {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        width: 100%;
+        cursor: pointer;
+        text-align: left;
+        font-family: inherit;
+        font-size: 13.5px;
+        color: var(--c-on-accent);
+        background: var(--c-accent);
+        border: 1px solid var(--c-accent);
+        border-radius: var(--radius);
+        padding: calc(var(--density) * 11px) 13px;
+        text-shadow: none;
+      }
+      .cmd-btn:hover {
+        filter: brightness(1.08);
+      }
+      .cmd-btn .caret {
+        font-weight: 700;
+      }
+      .cmd-btn svg {
+        width: 15px;
+        height: 15px;
+        margin-left: auto;
+      }
+      .links {
+        display: grid;
+        gap: 2px;
+      }
+      .link {
+        display: grid;
+        grid-template-columns: 1.1em 1fr auto;
+        align-items: baseline;
+        gap: 9px;
+        text-decoration: none;
+        color: inherit;
+        padding: calc(var(--density) * 8px) 8px;
+        border: 1px solid transparent;
+        border-radius: calc(var(--radius) * 0.6);
+      }
+      .link:hover {
+        border-color: var(--c-border);
+        background: color-mix(in srgb, var(--c-accent) 8%, transparent);
+      }
+      .link .mark {
+        color: var(--c-accent);
+      }
+      .link .name {
+        font-weight: 600;
+      }
+      .link .host {
+        color: var(--c-muted);
+        font-size: 11.5px;
+      }
+      .link .host::before {
+        content: "# ";
+      }
+      .win-foot {
+        border-top: 1px solid var(--c-border);
+        padding: 9px 15px;
+        font-size: 11px;
+        color: var(--c-muted);
+        display: flex;
+        justify-content: space-between;
+      }
+      .blink {
+        display: inline-block;
+        width: 8px;
+        height: 14px;
+        background: var(--c-accent);
+        vertical-align: text-bottom;
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      /* Options */
+      .options {
+        width: 460px;
+        max-width: 100%;
+      }
+      .opt-body {
+        padding: calc(var(--density) * 16px);
+        font-size: 13px;
+        display: grid;
+        gap: calc(var(--density) * 18px);
+      }
+      .section-h {
+        color: var(--c-accent);
+        margin: 0 0 calc(var(--density) * 10px);
+        font-size: 13px;
+      }
+      .kv {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        padding: calc(var(--density) * 7px) 0;
+        border-bottom: 1px dashed var(--c-border);
+      }
+      .kv:last-child {
+        border-bottom: 0;
+      }
+      .kv .k {
+        color: var(--c-text);
+      }
+      .kv .k .hint {
+        display: block;
+        color: var(--c-muted);
+        font-size: 11.5px;
+      }
+      select {
+        font: inherit;
+        font-size: 12.5px;
+        color: var(--c-text);
+        background: var(--c-bg);
+        border: 1px solid var(--c-border);
+        border-radius: calc(var(--radius) * 0.6);
+        padding: 6px 9px;
+      }
+      /* square terminal toggle */
+      .tog {
+        position: relative;
+        width: 46px;
+        height: 22px;
+        flex: none;
+        cursor: pointer;
+      }
+      .tog input {
+        position: absolute;
+        opacity: 0;
+      }
+      .tog .box {
+        position: absolute;
+        inset: 0;
+        border: 1px solid var(--c-border);
+        border-radius: calc(var(--radius) * 0.5);
+        color: var(--c-muted);
+        font-size: 10px;
+        letter-spacing: 0.1em;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding-right: 6px;
+      }
+      .tog .box::before {
+        content: "OFF";
+      }
+      .tog .box::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 16px;
+        height: 16px;
+        background: var(--c-muted);
+        transition: 0.15s ease;
+      }
+      .tog input:checked + .box {
+        border-color: var(--c-accent);
+        color: var(--c-accent);
+        justify-content: flex-start;
+        padding-left: 6px;
+      }
+      .tog input:checked + .box::before {
+        content: "ON";
+      }
+      .tog input:checked + .box::after {
+        left: auto;
+        right: 2px;
+        background: var(--c-accent);
+        box-shadow: 0 0 8px color-mix(in srgb, var(--c-accent) 60%, transparent);
+      }
+      .about-lines {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 4px;
+        color: var(--c-muted);
+      }
+      .about-lines a {
+        color: var(--c-accent);
+        text-decoration: none;
+      }
+      .about-lines a:hover {
+        text-decoration: underline;
+      }
+
+      .design-notes {
+        position: relative;
+        z-index: 2;
+        max-width: 780px;
+        margin: 0 auto 40px;
+        color: var(--c-muted);
+        font-size: 13px;
+      }
+      .design-notes summary {
+        cursor: pointer;
+        color: var(--c-text);
+      }
+      .design-notes p {
+        margin: 10px 0 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="stage">
+      <!-- Popup surface -->
+      <div class="surface">
+        <div class="surface-label">Toolbar popup · 340px</div>
+        <div class="popup win">
+          <div class="win-bar">
+            <span class="dots"><i></i><i></i><i></i></span>
+            <b><span class="prompt">➜</span> codeselfstudy</b>
+          </div>
+          <div class="win-body">
+            <pre class="banner">
+┌─ code self study ─┐
+└ share · learn · ship ┘</pre>
+            <button class="cmd-btn">
+              <span class="caret">❯</span> share --current-page
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+                <path d="M12 3v13" />
+                <path d="m7 8 5-5 5 5" />
+              </svg>
+            </button>
+            <nav class="links">
+              <a class="link" href="#">
+                <span class="mark">›</span>
+                <span
+                  ><span class="name">forum</span>
+                  <span class="host">forum.codeselfstudy.com</span></span
+                >
+              </a>
+              <a class="link" href="#">
+                <span class="mark">›</span>
+                <span
+                  ><span class="name">meetups</span>
+                  <span class="host">meetup.com/codeselfstudy</span></span
+                >
+              </a>
+              <a class="link" href="#">
+                <span class="mark">›</span>
+                <span
+                  ><span class="name">chat</span>
+                  <span class="host">codeselfstudy.slack.com</span></span
+                >
+              </a>
+            </nav>
+          </div>
+          <div class="win-foot">
+            <span>ready<span class="blink"></span></span>
+            <span>v0.11.0</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Options surface -->
+      <div class="surface">
+        <div class="surface-label">Options page</div>
+        <div class="options win">
+          <div class="win-bar">
+            <span class="dots"><i></i><i></i><i></i></span>
+            <b><span class="prompt">➜</span> codeselfstudy --config</b>
+          </div>
+          <div class="opt-body">
+            <section>
+              <h2 class="section-h">[sharing]</h2>
+              <div class="kv">
+                <span class="k">default_category</span>
+                <select>
+                  <option>general-discussion</option>
+                  <option>help</option>
+                  <option>show-and-tell</option>
+                  <option>resources</option>
+                </select>
+              </div>
+              <div class="kv">
+                <span class="k"
+                  >selection_as_quote
+                  <span class="hint"
+                    >wrap selection as a markdown blockquote</span
+                  >
+                </span>
+                <label class="tog"
+                  ><input type="checkbox" checked /><span class="box"></span
+                ></label>
+              </div>
+              <div class="kv">
+                <span class="k">open_in_new_tab</span>
+                <label class="tog"
+                  ><input type="checkbox" checked /><span class="box"></span
+                ></label>
+              </div>
+            </section>
+            <section>
+              <h2 class="section-h">[about]</h2>
+              <ul class="about-lines">
+                <li>one-click sharing to the code self study forum</li>
+                <li>
+                  <a href="#">forum</a> · <a href="#">meetups</a> ·
+                  <a href="#">chat</a>
+                </li>
+                <li>version 0.11.0 — MIT</li>
+              </ul>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <details class="design-notes">
+      <summary>Design notes — 02 · Terminal</summary>
+      <p>
+        <strong>Direction:</strong> a developer-console feel. Each surface is a
+        terminal window with a title bar, the primary action reads as a command
+        (<code>❯ share --current-page</code>), links are a menu, and the options
+        page is a config file of <code>key = value</code> rows with square
+        ON/OFF toggles. A faint CRT scanline (tinted from the text color) sits
+        over everything.
+      </p>
+      <p>
+        <strong>Typography:</strong> monospace throughout — the closest system
+        stack to the extension's real vendored Inconsolata. A second monospace
+        stack is offered as an alternate.
+      </p>
+      <p>
+        <strong>Palettes:</strong> Phosphor green (the current UI's
+        <code>#41ff00</code> lineage), Amber (vintage CRT), and Ice cyan. Dark
+        is the native mode; each palette also ships a readable "paper terminal"
+        light variant.
+      </p>
+    </details>
+
+    <!-- DP:STYLE -->
+    <style id="dp-style">
+      #design-panel {
+        --dp-bg: rgba(28, 30, 34, 0.92);
+        --dp-text: #e7e9ee;
+        --dp-muted: #9aa1ad;
+        --dp-line: rgba(255, 255, 255, 0.14);
+        --dp-active: #6ea8fe;
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        z-index: 99999;
+        width: 240px;
+        max-height: min(70vh, 560px);
+        overflow: auto;
+        background: var(--dp-bg);
+        color: var(--dp-text);
+        font:
+          12px/1.45 system-ui,
+          -apple-system,
+          "Segoe UI",
+          sans-serif;
+        border: 1px solid var(--dp-line);
+        border-radius: 10px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(6px);
+      }
+      #design-panel * {
+        box-sizing: border-box;
+        font: inherit;
+        color: inherit;
+      }
+      #design-panel header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--dp-line);
+      }
+      #design-panel header strong {
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      #dp-toggle {
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        padding: 2px 6px;
+        border-radius: 6px;
+        line-height: 1;
+      }
+      #dp-toggle:hover {
+        background: var(--dp-line);
+      }
+      #design-panel[data-collapsed="true"] {
+        width: auto;
+        max-height: none;
+        overflow: hidden;
+      }
+      #design-panel[data-collapsed="true"] #dp-body {
+        display: none;
+      }
+      #design-panel[data-collapsed="true"] header {
+        border-bottom: 0;
+      }
+      #dp-body {
+        padding: 10px 12px 12px;
+        display: grid;
+        gap: 12px;
+      }
+      #design-panel fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+      }
+      #design-panel legend {
+        padding: 0 0 6px;
+        color: var(--dp-muted);
+        text-transform: uppercase;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+      }
+      #design-panel .dp-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      #design-panel .dp-options label {
+        border: 1px solid var(--dp-line);
+        border-radius: 999px;
+        padding: 3px 10px;
+        cursor: pointer;
+        user-select: none;
+      }
+      #design-panel .dp-options input {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+      }
+      #design-panel .dp-options input:checked + span {
+        color: var(--dp-active);
+      }
+      #design-panel .dp-options label:has(input:checked) {
+        border-color: var(--dp-active);
+      }
+      #design-panel .dp-slider {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 8px;
+      }
+      #design-panel .dp-slider input[type="range"] {
+        width: 100%;
+        accent-color: var(--dp-active);
+      }
+      #design-panel .dp-slider output {
+        min-width: 42px;
+        text-align: right;
+        color: var(--dp-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      #dp-reset {
+        width: 100%;
+        border: 1px solid var(--dp-line);
+        background: transparent;
+        border-radius: 8px;
+        padding: 6px 0;
+        cursor: pointer;
+      }
+      #dp-reset:hover {
+        border-color: var(--dp-active);
+        color: var(--dp-active);
+      }
+    </style>
+    <!-- /DP:STYLE -->
+
+    <!-- DP:MARKUP -->
+    <aside
+      id="design-panel"
+      data-collapsed="false"
+      aria-label="Design control panel"
+    >
+      <header>
+        <strong>Design panel</strong>
+        <button
+          id="dp-toggle"
+          type="button"
+          aria-expanded="true"
+          title="Collapse panel"
+        >
+          −
+        </button>
+      </header>
+      <div id="dp-body">
+        <fieldset data-dp-group="mode">
+          <legend>Mode</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset data-dp-group="palette">
+          <legend>Palette</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset data-dp-group="font">
+          <legend>Font</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset>
+          <legend>Radius</legend>
+          <div class="dp-slider">
+            <input
+              type="range"
+              data-dp-range="radius"
+              min="0"
+              max="24"
+              step="1"
+            />
+            <output data-dp-out="radius"></output>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Density</legend>
+          <div class="dp-slider">
+            <input
+              type="range"
+              data-dp-range="density"
+              min="0.8"
+              max="1.3"
+              step="0.05"
+            />
+            <output data-dp-out="density"></output>
+          </div>
+        </fieldset>
+        <button id="dp-reset" type="button">Reset to defaults</button>
+      </div>
+    </aside>
+    <!-- /DP:MARKUP -->
+
+    <script>
+      window.DP_CONFIG = {
+        slug: "02-terminal",
+        palettes: [
+          { id: "phosphor", label: "Phosphor" },
+          { id: "amber", label: "Amber" },
+          { id: "ice", label: "Ice" },
+        ],
+        fonts: [
+          {
+            id: "mono",
+            label: "Mono",
+            body: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+            heading: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+          },
+          {
+            id: "courier",
+            label: "Courier",
+            body: "'Courier New', Courier, monospace",
+            heading: "'Courier New', Courier, monospace",
+          },
+        ],
+        defaults: {
+          mode: "dark",
+          palette: "phosphor",
+          font: "mono",
+          radius: 3,
+          density: 1,
+        },
+      };
+    </script>
+
+    <!-- DP:SCRIPT -->
+    <script id="dp-script">
+      (function () {
+        var config = window.DP_CONFIG;
+        if (
+          !config ||
+          !config.slug ||
+          !Array.isArray(config.palettes) ||
+          !Array.isArray(config.fonts)
+        ) {
+          console.error(
+            "design-panel: window.DP_CONFIG is missing or malformed"
+          );
+          return;
+        }
+        var KEY = "design-panel:" + config.slug;
+        var root = document.documentElement;
+        var panel = document.getElementById("design-panel");
+        var defaults = {
+          mode: config.defaults.mode === "dark" ? "dark" : "light",
+          palette: idOrFirst(config.palettes, config.defaults.palette),
+          font: idOrFirst(config.fonts, config.defaults.font),
+          radius: clamp(num(config.defaults.radius, 8), 0, 24),
+          density: clamp(num(config.defaults.density, 1), 0.8, 1.3),
+          collapsed: false,
+        };
+
+        function idOrFirst(list, id) {
+          for (var i = 0; i < list.length; i += 1) {
+            if (list[i].id === id) return id;
+          }
+          return list.length > 0 ? list[0].id : "";
+        }
+        function hasId(list, id) {
+          for (var i = 0; i < list.length; i += 1) {
+            if (list[i].id === id) return true;
+          }
+          return false;
+        }
+        function num(value, fallback) {
+          return typeof value === "number" && isFinite(value)
+            ? value
+            : fallback;
+        }
+        function clamp(value, min, max) {
+          return Math.min(max, Math.max(min, value));
+        }
+        function findFont(id) {
+          for (var i = 0; i < config.fonts.length; i += 1) {
+            if (config.fonts[i].id === id) return config.fonts[i];
+          }
+          return config.fonts[0];
+        }
+
+        function load() {
+          var state = {};
+          try {
+            state = JSON.parse(localStorage.getItem(KEY) || "{}") || {};
+          } catch (error) {
+            state = {};
+          }
+          return {
+            mode:
+              state.mode === "dark" || state.mode === "light"
+                ? state.mode
+                : defaults.mode,
+            palette: hasId(config.palettes, state.palette)
+              ? state.palette
+              : defaults.palette,
+            font: hasId(config.fonts, state.font) ? state.font : defaults.font,
+            radius: clamp(num(state.radius, defaults.radius), 0, 24),
+            density: clamp(num(state.density, defaults.density), 0.8, 1.3),
+            collapsed: state.collapsed === true,
+          };
+        }
+        function save() {
+          try {
+            localStorage.setItem(
+              KEY,
+              JSON.stringify(Object.assign({ v: 1 }, current))
+            );
+          } catch (error) {
+            /* storage unavailable (e.g. some file:// modes): live state still works */
+          }
+        }
+
+        var current = load();
+
+        function apply() {
+          root.setAttribute("data-theme", current.mode);
+          root.setAttribute("data-palette", current.palette);
+          root.setAttribute("data-font", current.font);
+          root.style.setProperty("--radius", current.radius + "px");
+          root.style.setProperty("--density", String(current.density));
+          var font = findFont(current.font);
+          root.style.setProperty("--font-body", font.body);
+          root.style.setProperty("--font-heading", font.heading || font.body);
+          panel.setAttribute("data-collapsed", String(current.collapsed));
+          var toggle = document.getElementById("dp-toggle");
+          toggle.textContent = current.collapsed ? "✦" : "−";
+          toggle.setAttribute("aria-expanded", String(!current.collapsed));
+          toggle.setAttribute(
+            "title",
+            current.collapsed ? "Expand panel" : "Collapse panel"
+          );
+          syncControls();
+        }
+
+        function radioGroup(group, options, getValue) {
+          var container = panel.querySelector(
+            '[data-dp-group="' + group + '"] .dp-options'
+          );
+          options.forEach(function (option) {
+            var label = document.createElement("label");
+            var input = document.createElement("input");
+            input.type = "radio";
+            input.name = "dp-" + group + "-" + config.slug;
+            input.setAttribute("value", option.id);
+            input.addEventListener("change", function () {
+              current[group] = option.id;
+              save();
+              apply();
+            });
+            var text = document.createElement("span");
+            text.textContent = option.label;
+            label.appendChild(input);
+            label.appendChild(text);
+            container.appendChild(label);
+          });
+        }
+
+        function syncControls() {
+          ["mode", "palette", "font"].forEach(function (group) {
+            var inputs = panel.querySelectorAll(
+              '[data-dp-group="' + group + '"] input'
+            );
+            inputs.forEach(function (input) {
+              input.checked = input.value === current[group];
+            });
+          });
+          var radius = panel.querySelector('[data-dp-range="radius"]');
+          var density = panel.querySelector('[data-dp-range="density"]');
+          radius.value = String(current.radius);
+          density.value = String(current.density);
+          panel.querySelector('[data-dp-out="radius"]').textContent =
+            current.radius + "px";
+          panel.querySelector('[data-dp-out="density"]').textContent =
+            "×" + current.density.toFixed(2);
+        }
+
+        radioGroup("mode", [
+          { id: "light", label: "Light" },
+          { id: "dark", label: "Dark" },
+        ]);
+        radioGroup("palette", config.palettes);
+        radioGroup("font", config.fonts);
+
+        panel
+          .querySelector('[data-dp-range="radius"]')
+          .addEventListener("input", function (event) {
+            current.radius = clamp(
+              num(Number(event.target.value), defaults.radius),
+              0,
+              24
+            );
+            save();
+            apply();
+          });
+        panel
+          .querySelector('[data-dp-range="density"]')
+          .addEventListener("input", function (event) {
+            current.density = clamp(
+              num(Number(event.target.value), defaults.density),
+              0.8,
+              1.3
+            );
+            save();
+            apply();
+          });
+        document
+          .getElementById("dp-toggle")
+          .addEventListener("click", function () {
+            current.collapsed = !current.collapsed;
+            save();
+            apply();
+          });
+        document
+          .getElementById("dp-reset")
+          .addEventListener("click", function () {
+            try {
+              localStorage.removeItem(KEY);
+            } catch (error) {
+              /* ignore */
+            }
+            current = load();
+            apply();
+          });
+
+        apply();
+      })();
+    </script>
+    <!-- /DP:SCRIPT -->
+  </body>
+</html>

--- a/mockups/03-brutalist.html
+++ b/mockups/03-brutalist.html
@@ -1,0 +1,962 @@
+<!doctype html>
+<html lang="en" data-theme="light" data-palette="concrete" data-font="grotesk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>03 · Brutalist — Code Self Study mockup</title>
+    <style>
+      /* ---- Palettes: muted / desaturated, all 7 contract vars, light AND dark.
+             --c-border doubles as the heavy "ink" line color. ---- */
+      [data-palette="concrete"] {
+        --c-bg: #e8e6e1;
+        --c-surface: #f4f2ed;
+        --c-text: #1b1a18;
+        --c-muted: #6d6a63;
+        --c-accent: #3c3936;
+        --c-on-accent: #f4f2ed;
+        --c-border: #1b1a18;
+      }
+      [data-palette="concrete"][data-theme="dark"] {
+        --c-bg: #161513;
+        --c-surface: #1f1e1b;
+        --c-text: #eae7e0;
+        --c-muted: #9a968c;
+        --c-accent: #d6d1c6;
+        --c-on-accent: #161513;
+        --c-border: #eae7e0;
+      }
+      [data-palette="ochre"] {
+        --c-bg: #ece6db;
+        --c-surface: #f6f1e6;
+        --c-text: #241f16;
+        --c-muted: #6f6552;
+        --c-accent: #986713;
+        --c-on-accent: #f6f1e6;
+        --c-border: #241f16;
+      }
+      [data-palette="ochre"][data-theme="dark"] {
+        --c-bg: #16130c;
+        --c-surface: #201c13;
+        --c-text: #ece3d0;
+        --c-muted: #a08f6f;
+        --c-accent: #c99a4a;
+        --c-on-accent: #16130c;
+        --c-border: #ece3d0;
+      }
+      [data-palette="sage"] {
+        --c-bg: #e3e7e1;
+        --c-surface: #eef1ea;
+        --c-text: #1a1f1a;
+        --c-muted: #63705f;
+        --c-accent: #4f6b54;
+        --c-on-accent: #eef1ea;
+        --c-border: #1a1f1a;
+      }
+      [data-palette="sage"][data-theme="dark"] {
+        --c-bg: #11150f;
+        --c-surface: #1a1f16;
+        --c-text: #e0e7dd;
+        --c-muted: #8b9884;
+        --c-accent: #8fae86;
+        --c-on-accent: #11150f;
+        --c-border: #e0e7dd;
+      }
+
+      /* ---- Component CSS: contract variables only ---- */
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--c-bg);
+        color: var(--c-text);
+        font-family: var(--font-body);
+        line-height: 1.45;
+      }
+      .stage {
+        display: flex;
+        flex-wrap: wrap;
+        gap: calc(var(--density) * 34px);
+        align-items: flex-start;
+        justify-content: center;
+        padding: calc(var(--density) * 44px) 24px 130px;
+        max-width: 920px;
+        margin: 0 auto;
+      }
+      .surface {
+        display: flex;
+        flex-direction: column;
+        gap: calc(var(--density) * 12px);
+      }
+      .surface-label {
+        font-family: var(--font-heading);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--c-text);
+        border-bottom: 3px solid var(--c-border);
+        padding-bottom: 4px;
+      }
+
+      .block {
+        background: var(--c-surface);
+        border: 3px solid var(--c-border);
+        border-radius: var(--radius);
+        box-shadow: calc(var(--density) * 7px) calc(var(--density) * 7px) 0
+          var(--c-border);
+      }
+
+      /* Popup */
+      .popup {
+        width: 320px;
+      }
+      .pop-head {
+        border-bottom: 3px solid var(--c-border);
+        padding: calc(var(--density) * 14px) 16px;
+        background: var(--c-accent);
+        color: var(--c-on-accent);
+      }
+      .pop-head h1 {
+        font-family: var(--font-heading);
+        margin: 0;
+        font-size: 21px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+        text-transform: uppercase;
+        line-height: 0.98;
+      }
+      .pop-head p {
+        margin: 5px 0 0;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .pop-body {
+        padding: calc(var(--density) * 16px);
+        display: grid;
+        gap: calc(var(--density) * 12px);
+      }
+      .big-btn {
+        width: 100%;
+        cursor: pointer;
+        font-family: var(--font-heading);
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+        font-size: 15px;
+        color: var(--c-on-accent);
+        background: var(--c-accent);
+        border: 3px solid var(--c-border);
+        border-radius: var(--radius);
+        padding: calc(var(--density) * 13px) 14px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 9px;
+        box-shadow: 4px 4px 0 var(--c-border);
+      }
+      .big-btn:hover {
+        transform: translate(2px, 2px);
+        box-shadow: 2px 2px 0 var(--c-border);
+      }
+      .big-btn:active {
+        transform: translate(4px, 4px);
+        box-shadow: 0 0 0 var(--c-border);
+      }
+      .big-btn svg {
+        width: 18px;
+        height: 18px;
+      }
+      .links {
+        display: grid;
+        gap: calc(var(--density) * 8px);
+      }
+      .link {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        text-decoration: none;
+        color: inherit;
+        border: 2px solid var(--c-border);
+        border-radius: var(--radius);
+        padding: calc(var(--density) * 10px) 12px;
+        background: var(--c-surface);
+      }
+      .link:hover {
+        background: var(--c-accent);
+        color: var(--c-on-accent);
+      }
+      .link .num {
+        font-family: var(--font-heading);
+        font-weight: 800;
+        font-size: 15px;
+        min-width: 22px;
+      }
+      .link .txt b {
+        display: block;
+        font-weight: 800;
+        text-transform: uppercase;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+      }
+      .link .txt span {
+        font-size: 11px;
+        color: var(--c-muted);
+      }
+      .link:hover .txt span {
+        color: var(--c-on-accent);
+      }
+      .link .arr {
+        margin-left: auto;
+        font-family: var(--font-heading);
+        font-weight: 800;
+      }
+      .pop-foot {
+        border-top: 3px solid var(--c-border);
+        padding: 9px 16px;
+        display: flex;
+        justify-content: space-between;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--c-muted);
+      }
+
+      /* Options */
+      .options {
+        width: 460px;
+        max-width: 100%;
+        display: grid;
+        gap: calc(var(--density) * 18px);
+      }
+      .opt-title {
+        font-family: var(--font-heading);
+        font-weight: 800;
+        text-transform: uppercase;
+        font-size: 30px;
+        line-height: 0.95;
+        margin: 0;
+        letter-spacing: -0.01em;
+      }
+      .opt-title span {
+        display: block;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        color: var(--c-muted);
+        margin-top: 6px;
+      }
+      .panel {
+        background: var(--c-surface);
+        border: 3px solid var(--c-border);
+        border-radius: var(--radius);
+        box-shadow: calc(var(--density) * 7px) calc(var(--density) * 7px) 0
+          var(--c-border);
+        overflow: hidden;
+      }
+      .panel h2 {
+        font-family: var(--font-heading);
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 13px;
+        margin: 0;
+        padding: calc(var(--density) * 11px) 16px;
+        background: var(--c-text);
+        color: var(--c-bg);
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: calc(var(--density) * 12px) 16px;
+        border-top: 2px solid var(--c-border);
+      }
+      .row:first-of-type {
+        border-top: 0;
+      }
+      .row .rlabel {
+        font-weight: 700;
+        font-size: 13.5px;
+      }
+      .row .rhint {
+        display: block;
+        font-weight: 400;
+        font-size: 11.5px;
+        color: var(--c-muted);
+        margin-top: 2px;
+      }
+      select {
+        font: inherit;
+        font-weight: 700;
+        font-size: 12.5px;
+        color: var(--c-text);
+        background: var(--c-bg);
+        border: 2px solid var(--c-border);
+        border-radius: 0;
+        padding: 7px 9px;
+      }
+      .sw {
+        position: relative;
+        width: 54px;
+        height: 26px;
+        flex: none;
+        cursor: pointer;
+      }
+      .sw input {
+        position: absolute;
+        opacity: 0;
+      }
+      .sw .b {
+        position: absolute;
+        inset: 0;
+        border: 2px solid var(--c-border);
+        background: var(--c-bg);
+      }
+      .sw .b::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 18px;
+        height: 18px;
+        background: var(--c-border);
+        transition: transform 0.12s steps(3);
+      }
+      .sw input:checked + .b {
+        background: var(--c-accent);
+      }
+      .sw input:checked + .b::after {
+        transform: translateX(28px);
+        background: var(--c-on-accent);
+      }
+      .about-body {
+        padding: calc(var(--density) * 14px) 16px calc(var(--density) * 16px);
+      }
+      .about-body p {
+        margin: 0 0 12px;
+        font-size: 13.5px;
+      }
+      .tags {
+        list-style: none;
+        margin: 0 0 12px;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .tags a {
+        font-family: var(--font-heading);
+        font-weight: 800;
+        text-transform: uppercase;
+        font-size: 11px;
+        letter-spacing: 0.05em;
+        text-decoration: none;
+        color: var(--c-text);
+        border: 2px solid var(--c-border);
+        padding: 5px 10px;
+      }
+      .tags a:hover {
+        background: var(--c-accent);
+        color: var(--c-on-accent);
+      }
+      .ver {
+        margin: 0;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--c-muted);
+      }
+
+      .design-notes {
+        max-width: 780px;
+        margin: 0 auto 40px;
+        color: var(--c-muted);
+        font-size: 13px;
+      }
+      .design-notes summary {
+        cursor: pointer;
+        color: var(--c-text);
+        font-family: var(--font-heading);
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .design-notes p {
+        margin: 10px 0 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="stage">
+      <!-- Popup surface -->
+      <div class="surface">
+        <div class="surface-label">Toolbar popup · 320px</div>
+        <div class="popup block">
+          <div class="pop-head">
+            <h1>Code Self Study</h1>
+            <p>Share · Learn · Ship</p>
+          </div>
+          <div class="pop-body">
+            <button class="big-btn">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+                <path d="M12 3v13" />
+                <path d="m7 8 5-5 5 5" />
+              </svg>
+              Share Page
+            </button>
+            <nav class="links">
+              <a class="link" href="#">
+                <span class="num">01</span>
+                <span class="txt"
+                  ><b>Coding Forum</b><span>forum.codeselfstudy.com</span></span
+                >
+                <span class="arr">→</span>
+              </a>
+              <a class="link" href="#">
+                <span class="num">02</span>
+                <span class="txt"
+                  ><b>SF Bay Meetups</b
+                  ><span>meetup.com/codeselfstudy</span></span
+                >
+                <span class="arr">→</span>
+              </a>
+              <a class="link" href="#">
+                <span class="num">03</span>
+                <span class="txt"
+                  ><b>Programming Chatroom</b
+                  ><span>codeselfstudy.slack.com</span></span
+                >
+                <span class="arr">→</span>
+              </a>
+            </nav>
+          </div>
+          <div class="pop-foot">
+            <span>Code Self Study</span>
+            <span>v0.11.0</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Options surface -->
+      <div class="surface">
+        <div class="surface-label">Options page</div>
+        <div class="options">
+          <h1 class="opt-title">
+            Options<span>Code Self Study Extension</span>
+          </h1>
+          <section class="panel">
+            <h2>Sharing</h2>
+            <div class="row">
+              <label class="rlabel" for="bcat">Default forum category</label>
+              <select id="bcat">
+                <option>General Discussion</option>
+                <option>Help &amp; Support</option>
+                <option>Show &amp; Tell</option>
+                <option>Resources</option>
+              </select>
+            </div>
+            <div class="row">
+              <span class="rlabel"
+                >Selected text as quote
+                <span class="rhint"
+                  >Wrap the selection as a markdown blockquote</span
+                >
+              </span>
+              <label class="sw"
+                ><input type="checkbox" checked /><span class="b"></span
+              ></label>
+            </div>
+            <div class="row">
+              <span class="rlabel">Open forum in a new tab</span>
+              <label class="sw"
+                ><input type="checkbox" checked /><span class="b"></span
+              ></label>
+            </div>
+          </section>
+          <section class="panel">
+            <h2>About</h2>
+            <div class="about-body">
+              <p>
+                One-click sharing of the page you're viewing to the Code Self
+                Study forum, plus quick links to the group's resources.
+              </p>
+              <ul class="tags">
+                <li><a href="#">Forum</a></li>
+                <li><a href="#">Meetups</a></li>
+                <li><a href="#">Chat</a></li>
+              </ul>
+              <p class="ver">Version 0.11.0 — MIT</p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <details class="design-notes">
+      <summary>Design notes — 03 · Brutalist (muted)</summary>
+      <p>
+        <strong>Direction:</strong> raw and structural — 3px ink borders, hard
+        offset drop-shadows, numbered link blocks, and a big uppercase wordmark.
+        The primary action is an oversized block button that physically
+        "presses" (shadow collapses) on click. Confident, but restrained.
+      </p>
+      <p>
+        <strong>Typography:</strong> a heavy grotesk (Arial Black / Helvetica
+        Neue system stack) for headings and controls, plain sans for body; a
+        monospace alternate is available for a more utilitarian read.
+      </p>
+      <p>
+        <strong>Palettes:</strong> deliberately muted, not neon — Concrete (warm
+        greys), Ochre (dusty mustard), and Sage (grey-green). Borders use the
+        text "ink" color, so the brutalist frame inverts cleanly between light
+        and dark.
+      </p>
+    </details>
+
+    <!-- DP:STYLE -->
+    <style id="dp-style">
+      #design-panel {
+        --dp-bg: rgba(28, 30, 34, 0.92);
+        --dp-text: #e7e9ee;
+        --dp-muted: #9aa1ad;
+        --dp-line: rgba(255, 255, 255, 0.14);
+        --dp-active: #6ea8fe;
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        z-index: 99999;
+        width: 240px;
+        max-height: min(70vh, 560px);
+        overflow: auto;
+        background: var(--dp-bg);
+        color: var(--dp-text);
+        font:
+          12px/1.45 system-ui,
+          -apple-system,
+          "Segoe UI",
+          sans-serif;
+        border: 1px solid var(--dp-line);
+        border-radius: 10px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(6px);
+      }
+      #design-panel * {
+        box-sizing: border-box;
+        font: inherit;
+        color: inherit;
+      }
+      #design-panel header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--dp-line);
+      }
+      #design-panel header strong {
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      #dp-toggle {
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        padding: 2px 6px;
+        border-radius: 6px;
+        line-height: 1;
+      }
+      #dp-toggle:hover {
+        background: var(--dp-line);
+      }
+      #design-panel[data-collapsed="true"] {
+        width: auto;
+        max-height: none;
+        overflow: hidden;
+      }
+      #design-panel[data-collapsed="true"] #dp-body {
+        display: none;
+      }
+      #design-panel[data-collapsed="true"] header {
+        border-bottom: 0;
+      }
+      #dp-body {
+        padding: 10px 12px 12px;
+        display: grid;
+        gap: 12px;
+      }
+      #design-panel fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+      }
+      #design-panel legend {
+        padding: 0 0 6px;
+        color: var(--dp-muted);
+        text-transform: uppercase;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+      }
+      #design-panel .dp-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      #design-panel .dp-options label {
+        border: 1px solid var(--dp-line);
+        border-radius: 999px;
+        padding: 3px 10px;
+        cursor: pointer;
+        user-select: none;
+      }
+      #design-panel .dp-options input {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+      }
+      #design-panel .dp-options input:checked + span {
+        color: var(--dp-active);
+      }
+      #design-panel .dp-options label:has(input:checked) {
+        border-color: var(--dp-active);
+      }
+      #design-panel .dp-slider {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 8px;
+      }
+      #design-panel .dp-slider input[type="range"] {
+        width: 100%;
+        accent-color: var(--dp-active);
+      }
+      #design-panel .dp-slider output {
+        min-width: 42px;
+        text-align: right;
+        color: var(--dp-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      #dp-reset {
+        width: 100%;
+        border: 1px solid var(--dp-line);
+        background: transparent;
+        border-radius: 8px;
+        padding: 6px 0;
+        cursor: pointer;
+      }
+      #dp-reset:hover {
+        border-color: var(--dp-active);
+        color: var(--dp-active);
+      }
+    </style>
+    <!-- /DP:STYLE -->
+
+    <!-- DP:MARKUP -->
+    <aside
+      id="design-panel"
+      data-collapsed="false"
+      aria-label="Design control panel"
+    >
+      <header>
+        <strong>Design panel</strong>
+        <button
+          id="dp-toggle"
+          type="button"
+          aria-expanded="true"
+          title="Collapse panel"
+        >
+          −
+        </button>
+      </header>
+      <div id="dp-body">
+        <fieldset data-dp-group="mode">
+          <legend>Mode</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset data-dp-group="palette">
+          <legend>Palette</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset data-dp-group="font">
+          <legend>Font</legend>
+          <div class="dp-options"></div>
+        </fieldset>
+        <fieldset>
+          <legend>Radius</legend>
+          <div class="dp-slider">
+            <input
+              type="range"
+              data-dp-range="radius"
+              min="0"
+              max="24"
+              step="1"
+            />
+            <output data-dp-out="radius"></output>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Density</legend>
+          <div class="dp-slider">
+            <input
+              type="range"
+              data-dp-range="density"
+              min="0.8"
+              max="1.3"
+              step="0.05"
+            />
+            <output data-dp-out="density"></output>
+          </div>
+        </fieldset>
+        <button id="dp-reset" type="button">Reset to defaults</button>
+      </div>
+    </aside>
+    <!-- /DP:MARKUP -->
+
+    <script>
+      window.DP_CONFIG = {
+        slug: "03-brutalist",
+        palettes: [
+          { id: "concrete", label: "Concrete" },
+          { id: "ochre", label: "Ochre" },
+          { id: "sage", label: "Sage" },
+        ],
+        fonts: [
+          {
+            id: "grotesk",
+            label: "Grotesk",
+            body: "'Helvetica Neue', Arial, sans-serif",
+            heading: "'Arial Black', 'Helvetica Neue', Impact, sans-serif",
+          },
+          {
+            id: "mono",
+            label: "Mono",
+            body: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+            heading: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+          },
+        ],
+        defaults: {
+          mode: "light",
+          palette: "concrete",
+          font: "grotesk",
+          radius: 0,
+          density: 1,
+        },
+      };
+    </script>
+
+    <!-- DP:SCRIPT -->
+    <script id="dp-script">
+      (function () {
+        var config = window.DP_CONFIG;
+        if (
+          !config ||
+          !config.slug ||
+          !Array.isArray(config.palettes) ||
+          !Array.isArray(config.fonts)
+        ) {
+          console.error(
+            "design-panel: window.DP_CONFIG is missing or malformed"
+          );
+          return;
+        }
+        var KEY = "design-panel:" + config.slug;
+        var root = document.documentElement;
+        var panel = document.getElementById("design-panel");
+        var defaults = {
+          mode: config.defaults.mode === "dark" ? "dark" : "light",
+          palette: idOrFirst(config.palettes, config.defaults.palette),
+          font: idOrFirst(config.fonts, config.defaults.font),
+          radius: clamp(num(config.defaults.radius, 8), 0, 24),
+          density: clamp(num(config.defaults.density, 1), 0.8, 1.3),
+          collapsed: false,
+        };
+
+        function idOrFirst(list, id) {
+          for (var i = 0; i < list.length; i += 1) {
+            if (list[i].id === id) return id;
+          }
+          return list.length > 0 ? list[0].id : "";
+        }
+        function hasId(list, id) {
+          for (var i = 0; i < list.length; i += 1) {
+            if (list[i].id === id) return true;
+          }
+          return false;
+        }
+        function num(value, fallback) {
+          return typeof value === "number" && isFinite(value)
+            ? value
+            : fallback;
+        }
+        function clamp(value, min, max) {
+          return Math.min(max, Math.max(min, value));
+        }
+        function findFont(id) {
+          for (var i = 0; i < config.fonts.length; i += 1) {
+            if (config.fonts[i].id === id) return config.fonts[i];
+          }
+          return config.fonts[0];
+        }
+
+        function load() {
+          var state = {};
+          try {
+            state = JSON.parse(localStorage.getItem(KEY) || "{}") || {};
+          } catch (error) {
+            state = {};
+          }
+          return {
+            mode:
+              state.mode === "dark" || state.mode === "light"
+                ? state.mode
+                : defaults.mode,
+            palette: hasId(config.palettes, state.palette)
+              ? state.palette
+              : defaults.palette,
+            font: hasId(config.fonts, state.font) ? state.font : defaults.font,
+            radius: clamp(num(state.radius, defaults.radius), 0, 24),
+            density: clamp(num(state.density, defaults.density), 0.8, 1.3),
+            collapsed: state.collapsed === true,
+          };
+        }
+        function save() {
+          try {
+            localStorage.setItem(
+              KEY,
+              JSON.stringify(Object.assign({ v: 1 }, current))
+            );
+          } catch (error) {
+            /* storage unavailable (e.g. some file:// modes): live state still works */
+          }
+        }
+
+        var current = load();
+
+        function apply() {
+          root.setAttribute("data-theme", current.mode);
+          root.setAttribute("data-palette", current.palette);
+          root.setAttribute("data-font", current.font);
+          root.style.setProperty("--radius", current.radius + "px");
+          root.style.setProperty("--density", String(current.density));
+          var font = findFont(current.font);
+          root.style.setProperty("--font-body", font.body);
+          root.style.setProperty("--font-heading", font.heading || font.body);
+          panel.setAttribute("data-collapsed", String(current.collapsed));
+          var toggle = document.getElementById("dp-toggle");
+          toggle.textContent = current.collapsed ? "✦" : "−";
+          toggle.setAttribute("aria-expanded", String(!current.collapsed));
+          toggle.setAttribute(
+            "title",
+            current.collapsed ? "Expand panel" : "Collapse panel"
+          );
+          syncControls();
+        }
+
+        function radioGroup(group, options, getValue) {
+          var container = panel.querySelector(
+            '[data-dp-group="' + group + '"] .dp-options'
+          );
+          options.forEach(function (option) {
+            var label = document.createElement("label");
+            var input = document.createElement("input");
+            input.type = "radio";
+            input.name = "dp-" + group + "-" + config.slug;
+            input.setAttribute("value", option.id);
+            input.addEventListener("change", function () {
+              current[group] = option.id;
+              save();
+              apply();
+            });
+            var text = document.createElement("span");
+            text.textContent = option.label;
+            label.appendChild(input);
+            label.appendChild(text);
+            container.appendChild(label);
+          });
+        }
+
+        function syncControls() {
+          ["mode", "palette", "font"].forEach(function (group) {
+            var inputs = panel.querySelectorAll(
+              '[data-dp-group="' + group + '"] input'
+            );
+            inputs.forEach(function (input) {
+              input.checked = input.value === current[group];
+            });
+          });
+          var radius = panel.querySelector('[data-dp-range="radius"]');
+          var density = panel.querySelector('[data-dp-range="density"]');
+          radius.value = String(current.radius);
+          density.value = String(current.density);
+          panel.querySelector('[data-dp-out="radius"]').textContent =
+            current.radius + "px";
+          panel.querySelector('[data-dp-out="density"]').textContent =
+            "×" + current.density.toFixed(2);
+        }
+
+        radioGroup("mode", [
+          { id: "light", label: "Light" },
+          { id: "dark", label: "Dark" },
+        ]);
+        radioGroup("palette", config.palettes);
+        radioGroup("font", config.fonts);
+
+        panel
+          .querySelector('[data-dp-range="radius"]')
+          .addEventListener("input", function (event) {
+            current.radius = clamp(
+              num(Number(event.target.value), defaults.radius),
+              0,
+              24
+            );
+            save();
+            apply();
+          });
+        panel
+          .querySelector('[data-dp-range="density"]')
+          .addEventListener("input", function (event) {
+            current.density = clamp(
+              num(Number(event.target.value), defaults.density),
+              0.8,
+              1.3
+            );
+            save();
+            apply();
+          });
+        document
+          .getElementById("dp-toggle")
+          .addEventListener("click", function () {
+            current.collapsed = !current.collapsed;
+            save();
+            apply();
+          });
+        document
+          .getElementById("dp-reset")
+          .addEventListener("click", function () {
+            try {
+              localStorage.removeItem(KEY);
+            } catch (error) {
+              /* ignore */
+            }
+            current = load();
+            apply();
+          });
+
+        apply();
+      })();
+    </script>
+    <!-- /DP:SCRIPT -->
+  </body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<!--
+  MOCKUP GALLERY — Code Self Study extension UI.
+  Links are the contract; iframe previews are best-effort (file:// rules vary).
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Code Self Study — design mockups</title>
+    <style>
+      :root {
+        --bg: #f5f6f8;
+        --surface: #ffffff;
+        --text: #16181d;
+        --muted: #5c6470;
+        --border: #e2e5ea;
+        --accent: #2563eb;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #111317;
+          --surface: #1a1d23;
+          --text: #e7e9ee;
+          --muted: #9aa1ad;
+          --border: #2a2e36;
+          --accent: #6ea8fe;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          15px/1.5 system-ui,
+          -apple-system,
+          "Segoe UI",
+          sans-serif;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 32px 20px 64px;
+      }
+      h1 {
+        font-size: 22px;
+        margin: 0 0 4px;
+      }
+      p.lead {
+        margin: 0 0 28px;
+        color: var(--muted);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 20px;
+      }
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .card .preview {
+        height: 200px;
+        overflow: hidden;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg);
+      }
+      .card .preview iframe {
+        width: 400%;
+        height: 800px;
+        border: 0;
+        transform: scale(0.25);
+        transform-origin: top left;
+        pointer-events: none;
+      }
+      .card .meta {
+        padding: 14px 16px 16px;
+      }
+      .card h2 {
+        font-size: 16px;
+        margin: 0 0 4px;
+      }
+      .card h2 a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .card h2 a:hover {
+        text-decoration: underline;
+      }
+      .card p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Code Self Study — design mockups</h1>
+      <p class="lead">
+        Three directions for the extension's toolbar popup and options page.
+        Open a mockup and use its design panel to explore modes, palettes,
+        fonts, radius, and density.
+      </p>
+      <div class="grid">
+        <article class="card">
+          <div class="preview">
+            <iframe
+              src="01-saas.html"
+              title="Modern SaaS preview"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="meta">
+            <h2><a href="01-saas.html">01 · Modern SaaS</a></h2>
+            <p>
+              Clean product UI — rounded cards, a soft accent action, light +
+              dark.
+            </p>
+          </div>
+        </article>
+        <article class="card">
+          <div class="preview">
+            <iframe
+              src="02-terminal.html"
+              title="Terminal preview"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="meta">
+            <h2><a href="02-terminal.html">02 · Terminal</a></h2>
+            <p>
+              Developer-console feel — monospace, window chrome, command-style
+              actions, CRT scanline.
+            </p>
+          </div>
+        </article>
+        <article class="card">
+          <div class="preview">
+            <iframe
+              src="03-brutalist.html"
+              title="Brutalist preview"
+              loading="lazy"
+            ></iframe>
+          </div>
+          <div class="meta">
+            <h2><a href="03-brutalist.html">03 · Brutalist (muted)</a></h2>
+            <p>
+              Raw structural blocks — heavy ink borders, hard offset shadows, a
+              muted palette.
+            </p>
+          </div>
+        </article>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Implements #35. Three self-contained design directions for the popup + options page in `mockups/` — 01 Modern SaaS, 02 Terminal, 03 Brutalist (muted) — each with the shared design control panel (light/dark, palettes, fonts, radius, density) and a gallery `index.html`. Verified in a browser: no console errors, offline (no network assets), light + dark render correctly. Open `mockups/index.html` to review and pick a direction for #37.