### PR TITLE
Implement Modern SaaS design (popup + options) with theme override

### DIFF
--- a/browserAction/index.html
+++ b/browserAction/index.html
@@ -5,35 +5,150 @@
     <link href="style.css" rel="stylesheet" />
   </head>
   <body>
-    <h1>
-      <a href="https://codeselfstudy.com/" target="_blank">Code Self Study</a>
-    </h1>
-    <ul>
-      <li>
-        <a title="Share this page in the forum" href="#" id="shareLink"
-          >Share Current Page</a
+    <div class="popup">
+      <header class="popup-head">
+        <span class="logo" aria-hidden="true">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+            <path d="M16 3h3a2 2 0 0 1 2 2v3" />
+            <path d="M8 21H5a2 2 0 0 1-2-2v-3" />
+            <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+            <path d="M9 12h6" />
+            <path d="M12 9v6" />
+          </svg>
+        </span>
+        <div class="brand">
+          <h1>Code Self Study</h1>
+          <p>Share to the community forum</p>
+        </div>
+        <button
+          id="openOptions"
+          class="icon-btn"
+          type="button"
+          title="Options"
+          aria-label="Open options"
         >
-      </li>
-      <li>
-        <a href="https://forum.codeselfstudy.com/" target="_blank"
-          >Coding Forum</a
-        >
-      </li>
-      <li>
-        <a href="https://www.meetup.com/codeselfstudy" target="_blank"
-          >SF Bay Meetups</a
-        >
-      </li>
-      <li>
-        <a href="https://codeselfstudy.slack.com/" target="_blank"
-          >Programming Chatroom</a
-        >
-      </li>
-    </ul>
-    <script
-      type="application/javascript"
-      src="../vendor/browser-polyfill.js"
-    ></script>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path
+              d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+            />
+          </svg>
+        </button>
+      </header>
+      <div class="popup-body">
+        <button id="shareLink" class="btn-primary" type="button">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+            <path d="M12 3v13" />
+            <path d="m7 8 5-5 5 5" />
+          </svg>
+          Share Current Page
+        </button>
+        <nav class="links" aria-label="Code Self Study resources">
+          <a
+            class="link"
+            href="https://forum.codeselfstudy.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="ico" aria-hidden="true"
+              ><svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+                /></svg
+            ></span>
+            <span class="txt"
+              ><b>Coding Forum</b><span>forum.codeselfstudy.com</span></span
+            >
+            <span class="chev" aria-hidden="true">›</span>
+          </a>
+          <a
+            class="link"
+            href="https://www.meetup.com/codeselfstudy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="ico" aria-hidden="true"
+              ><svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0 1 18 0z" />
+                <circle cx="12" cy="10" r="3" /></svg
+            ></span>
+            <span class="txt"
+              ><b>SF Bay Meetups</b><span>meetup.com/codeselfstudy</span></span
+            >
+            <span class="chev" aria-hidden="true">›</span>
+          </a>
+          <a
+            class="link"
+            href="https://codeselfstudy.slack.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="ico" aria-hidden="true"
+              ><svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="4" y1="9" x2="20" y2="9" />
+                <line x1="4" y1="15" x2="20" y2="15" />
+                <line x1="10" y1="3" x2="8" y2="21" />
+                <line x1="16" y1="3" x2="14" y2="21" /></svg
+            ></span>
+            <span class="txt"
+              ><b>Programming Chatroom</b
+              ><span>codeselfstudy.slack.com</span></span
+            >
+            <span class="chev" aria-hidden="true">›</span>
+          </a>
+        </nav>
+      </div>
+      <footer class="popup-foot">
+        <span>Code Self Study</span>
+        <span id="version"></span>
+      </footer>
+    </div>
+    <script src="../vendor/browser-polyfill.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/browserAction/script.js
+++ b/browserAction/script.js
@@ -4,20 +4,39 @@
 const DISCOURSE_BASE_URL = "https://forum.codeselfstudy.com";
 const NEW_TOPIC_URL = `${DISCOURSE_BASE_URL}/new-topic`;
 
-// An object that contains references to the elements in the browser action menu
+// Apply the saved appearance before anything else so the popup opens in the
+// right theme. "system" leaves data-theme unset and lets the CSS
+// prefers-color-scheme rules decide.
+applyStoredTheme();
+
 const els = {
   shareLink: document.getElementById("shareLink"),
+  openOptions: document.getElementById("openOptions"),
+  version: document.getElementById("version"),
 };
 
+// Show the real extension version in the footer.
+try {
+  els.version.textContent = "v" + browser.runtime.getManifest().version;
+} catch (err) {
+  /* getManifest unavailable in a plain preview: leave the footer blank */
+}
+
+els.openOptions.addEventListener("click", () => {
+  browser.runtime.openOptionsPage();
+  window.close();
+});
+
 els.shareLink.addEventListener("click", () => {
-  shareCurrentTab().catch((err) => console.error(err));
+  shareCurrentTab(readSettings()).catch((err) => console.error(err));
 });
 
 /**
  * Read the active tab (via activeTab + scripting), build a pre-filled
- * Discourse "new topic" URL from its title/URL/selection, and open it.
+ * Discourse "new topic" URL from its title/URL/selection, and open it
+ * according to the saved settings.
  */
-async function shareCurrentTab() {
+async function shareCurrentTab(settings) {
   const [tab] = await browser.tabs.query({
     currentWindow: true,
     active: true,
@@ -36,9 +55,18 @@ async function shareCurrentTab() {
   }
 
   const title = page.title.split("|")[0].trim();
-  const body = `${toMarkdownQuote(page.selection)}\n\n${page.url}`;
+  const selection = (page.selection || "").trim();
+  const body =
+    settings.quote && selection
+      ? `${toMarkdownQuote(page.selection)}\n\n${page.url}`
+      : page.url;
+  const url = generateSharingUrl(title, body, settings.category);
 
-  await browser.tabs.create({ url: generateSharingUrl(title, body) });
+  if (settings.newTab) {
+    await browser.tabs.create({ url });
+  } else {
+    await browser.tabs.update(tab.id, { url });
+  }
 
   // Close the popup or it will stay open on the new tab.
   window.close();
@@ -86,4 +114,43 @@ function toMarkdownQuote(text) {
     .split("\n")
     .map((line) => `> ${line}`)
     .join("\n");
+}
+
+/**
+ * Read the saved settings from localStorage. The popup and the options page are
+ * same-origin extension pages, so they share localStorage without needing the
+ * "storage" permission. Missing/invalid values fall back to defaults.
+ */
+function readSettings() {
+  let stored = {};
+  try {
+    stored = JSON.parse(localStorage.getItem("css.settings") || "{}") || {};
+  } catch (err) {
+    stored = {};
+  }
+  return {
+    theme:
+      stored.theme === "light" || stored.theme === "dark"
+        ? stored.theme
+        : "system",
+    category:
+      typeof stored.category === "string" && stored.category
+        ? stored.category
+        : "general-discussion",
+    quote: stored.quote !== false,
+    newTab: stored.newTab !== false,
+  };
+}
+
+/**
+ * Apply the saved appearance to <html>. "system" removes the override so the
+ * CSS prefers-color-scheme rules apply.
+ */
+function applyStoredTheme() {
+  const theme = readSettings().theme;
+  if (theme === "light" || theme === "dark") {
+    document.documentElement.setAttribute("data-theme", theme);
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
 }

--- a/browserAction/style.css
+++ b/browserAction/style.css
@@ -1,59 +1,211 @@
-/* @import url("../vendor/font-awesome-5.11.2-all.css"); */
-@font-face {
-  font-family: "Inconsolata";
-  src: url("../fonts/Inconsolata-Regular.ttf") format("truetype");
+/* Modern SaaS look, "Slate" palette. Follows the OS light/dark setting by
+   default; an explicit data-theme="light|dark" on <html> (set from the saved
+   Appearance option) overrides the system setting. */
+:root {
+  --c-bg: #f4f6f8;
+  --c-surface: #ffffff;
+  --c-text: #172029;
+  --c-muted: #64748b;
+  --c-accent: #2563eb;
+  --c-on-accent: #ffffff;
+  --c-border: #e2e8f0;
+  --radius: 10px;
+  --font: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --c-bg: #0d1219;
+    --c-surface: #151c26;
+    --c-text: #e6ecf3;
+    --c-muted: #94a3b8;
+    --c-accent: #6ea8fe;
+    --c-on-accent: #0a0f16;
+    --c-border: #253040;
+  }
+}
+:root[data-theme="light"] {
+  --c-bg: #f4f6f8;
+  --c-surface: #ffffff;
+  --c-text: #172029;
+  --c-muted: #64748b;
+  --c-accent: #2563eb;
+  --c-on-accent: #ffffff;
+  --c-border: #e2e8f0;
+}
+:root[data-theme="dark"] {
+  --c-bg: #0d1219;
+  --c-surface: #151c26;
+  --c-text: #e6ecf3;
+  --c-muted: #94a3b8;
+  --c-accent: #6ea8fe;
+  --c-on-accent: #0a0f16;
+  --c-border: #253040;
 }
 
+* {
+  box-sizing: border-box;
+}
 body {
-  background-color: #363636;
-  color: #fff;
-  font-family: "Inconsolata", monospace;
-  min-width: 200px;
-  /* margin: 0; */
-  /* padding: 0; */
-}
-
-ul {
-  padding: 0;
   margin: 0;
+  width: 320px;
+  background: var(--c-surface);
+  color: var(--c-text);
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
-
-li {
-  list-style-type: none;
-  margin: 19px 0;
+.popup {
+  display: flex;
+  flex-direction: column;
 }
-
-ul a,
-ul a:visited {
+.popup-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--c-border);
+}
+.logo {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--c-accent);
+  color: var(--c-on-accent);
+  flex: none;
+}
+.logo svg {
+  width: 17px;
+  height: 17px;
+}
+.brand {
+  flex: 1;
+  min-width: 0;
+}
+.brand h1 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+}
+.brand p {
+  margin: 1px 0 0;
+  font-size: 11.5px;
+  color: var(--c-muted);
+}
+.icon-btn {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background: var(--c-surface);
+  color: var(--c-muted);
+  cursor: pointer;
+}
+.icon-btn:hover {
+  color: var(--c-accent);
+  border-color: var(--c-accent);
+}
+.icon-btn svg {
+  width: 16px;
+  height: 16px;
+}
+.popup-body {
+  padding: 16px;
+  display: grid;
+  gap: 14px;
+}
+.btn-primary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  border: 0;
+  cursor: pointer;
+  padding: 11px 14px;
+  border-radius: var(--radius);
+  background: var(--c-accent);
+  color: var(--c-on-accent);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 8px 18px -10px var(--c-accent);
+}
+.btn-primary:hover {
+  filter: brightness(1.05);
+}
+.btn-primary:active {
+  transform: translateY(1px);
+}
+.btn-primary svg {
+  width: 16px;
+  height: 16px;
+}
+.links {
+  display: grid;
+  gap: 6px;
+}
+.link {
+  display: flex;
+  align-items: center;
+  gap: 11px;
   text-decoration: none;
-  padding: 7px;
-  background-color: #666;
-  border-radius: 2px;
-  color: #fff;
-  font-weight: bold;
-
-  /* TODO make these buttons full-width */
-  /* This isn't working */
-  /* width: 100%; */
+  color: inherit;
+  padding: 9px 10px;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
 }
-
-h1,
-h1 a,
-h1 a:visited {
-  color: #41ff00;
-  font-size: 1.27rem;
-  text-decoration: none;
+.link:hover {
+  background: var(--c-bg);
+  border-color: var(--c-border);
 }
-
-#codesOutput table th {
-  text-align: left;
+.link .ico {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border-radius: 8px;
+  background: var(--c-bg);
+  border: 1px solid var(--c-border);
+  color: var(--c-accent);
 }
-
-#codesOutput table {
-  border-collapse: collapse;
+.link .ico svg {
+  width: 16px;
+  height: 16px;
 }
-
-#codesOutput table td {
-  border: 1px solid #eee;
-  padding: 7px;
+.link .txt {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.link .txt b {
+  font-weight: 600;
+  font-size: 13.5px;
+}
+.link .txt span {
+  font-size: 11px;
+  color: var(--c-muted);
+}
+.link .chev {
+  margin-left: auto;
+  color: var(--c-muted);
+  opacity: 0.6;
+}
+.popup-foot {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-top: 1px solid var(--c-border);
+  font-size: 11px;
+  color: var(--c-muted);
+}
+:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 2px;
 }

--- a/options/index.html
+++ b/options/index.html
@@ -2,10 +2,118 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="style.css" rel="stylesheet" />
   </head>
   <body>
-    <h1 id="myHeading">Options coming soon</h1>
+    <main class="wrap">
+      <header class="page-head">
+        <span class="logo" aria-hidden="true">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+            <path d="M16 3h3a2 2 0 0 1 2 2v3" />
+            <path d="M8 21H5a2 2 0 0 1-2-2v-3" />
+            <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+            <path d="M9 12h6" />
+            <path d="M12 9v6" />
+          </svg>
+        </span>
+        <div>
+          <h1>Code Self Study</h1>
+          <p>Extension options</p>
+        </div>
+      </header>
+
+      <section class="card">
+        <h2>Appearance</h2>
+        <div class="field">
+          <label for="theme"
+            >Theme
+            <span class="hint"
+              >Follow your system setting, or force light / dark</span
+            >
+          </label>
+          <select id="theme">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Sharing</h2>
+        <div class="field">
+          <label for="category">Default forum category</label>
+          <select id="category">
+            <option value="general-discussion">General Discussion</option>
+            <option value="help">Help &amp; Support</option>
+            <option value="show-and-tell">Show &amp; Tell</option>
+            <option value="resources">Resources</option>
+          </select>
+        </div>
+        <div class="field">
+          <span class="flabel"
+            >Include selected text as a quote
+            <span class="hint"
+              >Wraps your selection as a markdown blockquote</span
+            >
+          </span>
+          <label class="switch"
+            ><input type="checkbox" id="quote" /><span class="track"></span
+          ></label>
+        </div>
+        <div class="field">
+          <span class="flabel">Open the forum in a new tab</span>
+          <label class="switch"
+            ><input type="checkbox" id="newTab" /><span class="track"></span
+          ></label>
+        </div>
+      </section>
+
+      <section class="card about">
+        <h2>About</h2>
+        <p>
+          One-click sharing of the page you're viewing to the Code Self Study
+          Discourse forum, plus quick links to the group's resources.
+        </p>
+        <ul class="about-links">
+          <li>
+            <a
+              href="https://forum.codeselfstudy.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Coding Forum</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.meetup.com/codeselfstudy"
+              target="_blank"
+              rel="noopener noreferrer"
+              >SF Bay Meetups</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://codeselfstudy.slack.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Programming Chatroom</a
+            >
+          </li>
+        </ul>
+        <p class="ver" id="version"></p>
+      </section>
+    </main>
+    <script src="../vendor/browser-polyfill.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/options/script.js
+++ b/options/script.js
@@ -1,1 +1,93 @@
-// Add JS for the options page here
+// Options page: reads and writes the settings shared with the popup via
+// localStorage (both are same-origin extension pages, so no "storage"
+// permission is needed).
+
+// Apply the saved appearance before paint.
+applyStoredTheme();
+
+const controls = {
+  theme: document.getElementById("theme"),
+  category: document.getElementById("category"),
+  quote: document.getElementById("quote"),
+  newTab: document.getElementById("newTab"),
+  version: document.getElementById("version"),
+};
+
+// Reflect the saved settings in the form.
+const settings = readSettings();
+controls.theme.value = settings.theme;
+controls.category.value = settings.category;
+controls.quote.checked = settings.quote;
+controls.newTab.checked = settings.newTab;
+
+try {
+  controls.version.textContent =
+    "Version " + browser.runtime.getManifest().version + " — MIT License";
+} catch (err) {
+  /* getManifest unavailable in a plain preview: leave it blank */
+}
+
+controls.theme.addEventListener("change", () => {
+  saveSettings({ theme: controls.theme.value });
+  applyStoredTheme();
+});
+controls.category.addEventListener("change", () => {
+  saveSettings({ category: controls.category.value });
+});
+controls.quote.addEventListener("change", () => {
+  saveSettings({ quote: controls.quote.checked });
+});
+controls.newTab.addEventListener("change", () => {
+  saveSettings({ newTab: controls.newTab.checked });
+});
+
+/**
+ * Read the saved settings from localStorage. Missing/invalid values fall back
+ * to defaults. (Kept in sync with the popup's copy.)
+ */
+function readSettings() {
+  let stored = {};
+  try {
+    stored = JSON.parse(localStorage.getItem("css.settings") || "{}") || {};
+  } catch (err) {
+    stored = {};
+  }
+  return {
+    theme:
+      stored.theme === "light" || stored.theme === "dark"
+        ? stored.theme
+        : "system",
+    category:
+      typeof stored.category === "string" && stored.category
+        ? stored.category
+        : "general-discussion",
+    quote: stored.quote !== false,
+    newTab: stored.newTab !== false,
+  };
+}
+
+/**
+ * Merge a patch into the saved settings and persist it.
+ */
+function saveSettings(patch) {
+  const next = Object.assign(readSettings(), patch);
+  try {
+    localStorage.setItem("css.settings", JSON.stringify(next));
+  } catch (err) {
+    /* storage unavailable: the live form still reflects the change */
+  }
+  return next;
+}
+
+/**
+ * Apply the saved appearance to <html>. "system" removes the override so the
+ * CSS prefers-color-scheme rules apply.
+ */
+function applyStoredTheme() {
+  const theme = readSettings().theme;
+  if (theme === "light" || theme === "dark") {
+    document.documentElement.setAttribute("data-theme", theme);
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}

--- a/options/style.css
+++ b/options/style.css
@@ -1,1 +1,203 @@
-/* CSS for the options page goes here */
+/* Modern SaaS look, "Slate" palette — matches the popup. Follows the OS
+   light/dark setting by default; an explicit data-theme="light|dark" on <html>
+   (set from the saved Appearance option) overrides it. */
+:root {
+  --c-bg: #f4f6f8;
+  --c-surface: #ffffff;
+  --c-text: #172029;
+  --c-muted: #64748b;
+  --c-accent: #2563eb;
+  --c-on-accent: #ffffff;
+  --c-border: #e2e8f0;
+  --radius: 10px;
+  --font: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --c-bg: #0d1219;
+    --c-surface: #151c26;
+    --c-text: #e6ecf3;
+    --c-muted: #94a3b8;
+    --c-accent: #6ea8fe;
+    --c-on-accent: #0a0f16;
+    --c-border: #253040;
+  }
+}
+:root[data-theme="light"] {
+  --c-bg: #f4f6f8;
+  --c-surface: #ffffff;
+  --c-text: #172029;
+  --c-muted: #64748b;
+  --c-accent: #2563eb;
+  --c-on-accent: #ffffff;
+  --c-border: #e2e8f0;
+}
+:root[data-theme="dark"] {
+  --c-bg: #0d1219;
+  --c-surface: #151c26;
+  --c-text: #e6ecf3;
+  --c-muted: #94a3b8;
+  --c-accent: #6ea8fe;
+  --c-on-accent: #0a0f16;
+  --c-border: #253040;
+}
+
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  background: var(--c-bg);
+  color: var(--c-text);
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 32px 20px 64px;
+  display: grid;
+  gap: 18px;
+}
+.page-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+.page-head .logo {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: var(--c-accent);
+  color: var(--c-on-accent);
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+.page-head .logo svg {
+  width: 22px;
+  height: 22px;
+}
+.page-head h1 {
+  margin: 0;
+  font-size: 22px;
+}
+.page-head p {
+  margin: 2px 0 0;
+  color: var(--c-muted);
+  font-size: 13px;
+}
+.card {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 14px;
+  padding: 18px;
+  box-shadow: 0 12px 30px -24px rgba(15, 20, 40, 0.5);
+}
+.card h2 {
+  font-size: 13px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--c-muted);
+  margin: 0 0 14px;
+}
+.field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-top: 1px solid var(--c-border);
+}
+.field:first-of-type {
+  border-top: 0;
+}
+.field label,
+.field .flabel {
+  font-size: 13.5px;
+}
+.field .hint {
+  display: block;
+  font-size: 11.5px;
+  color: var(--c-muted);
+  margin-top: 2px;
+}
+select {
+  font: inherit;
+  font-size: 13px;
+  color: var(--c-text);
+  background: var(--c-bg);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  padding: 7px 10px;
+}
+.switch {
+  position: relative;
+  width: 40px;
+  height: 23px;
+  flex: none;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+}
+.switch .track {
+  position: absolute;
+  inset: 0;
+  background: var(--c-border);
+  border-radius: 999px;
+  transition: background 0.15s ease;
+}
+.switch .track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  background: var(--c-surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease;
+}
+.switch input:checked + .track {
+  background: var(--c-accent);
+}
+.switch input:checked + .track::after {
+  transform: translateX(17px);
+}
+.about p {
+  margin: 0 0 10px;
+  font-size: 13.5px;
+}
+.about-links {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.about-links a {
+  font-size: 12.5px;
+  color: var(--c-accent);
+  text-decoration: none;
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  padding: 4px 11px;
+}
+.about-links a:hover {
+  border-color: var(--c-accent);
+}
+.ver {
+  font-size: 12px;
+  color: var(--c-muted);
+  margin: 0;
+}
+:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Implements #37.

Applies the chosen **Modern SaaS + Slate** direction to the shipping UI.

- **Popup**: SaaS/Slate design, options-gear button (`runtime.openOptionsPage`), version pulled from the manifest.
- **Options page**: real settings — Appearance (System/Light/Dark), Sharing (default category, selection-as-quote, open-in-new-tab), About — replacing the "coming soon" placeholder.
- **Theme**: follows `prefers-color-scheme` by default; an explicit `data-theme` override (from the Appearance setting) wins. Settings persist in `localStorage`, shared between popup and options (same-origin pages) so **no `storage` permission** is added.
- **Share** now honors the saved category / quote / new-tab settings; accessible focus outlines, aria labels, `rel=noopener`.

Verified in a browser: options + popup render in light and dark, the Appearance override persists and the popup picks it up (shared storage), no console errors. `bun test` 12 pass; `just build` both zips; `just lint` 0/0/0.