### PR TITLE
Remove Share button glow; bump to 0.11.2

### DIFF
--- a/browserAction/style.css
+++ b/browserAction/style.css
@@ -134,7 +134,6 @@ body {
   font-family: inherit;
   font-size: 14px;
   font-weight: 600;
-  box-shadow: 0 8px 18px -10px var(--c-accent);
 }
 .btn-primary:hover {
   filter: brightness(1.05);

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Code Self Study",
   "short_name": "codeselfstudy",
   "description": "A browser extension for Code Self Study (codeselfstudy.com)",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "icons": {
     "64": "icons/icon.png"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeselfstudy/codeselfstudy_browser_extension",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A browser extension for Code Self Study",
   "main": "background_script.js",
   "scripts": {


### PR DESCRIPTION
Flattens the primary **Share Current Page** button in the browser-action popup and bumps the extension to 0.11.2.

## What changed
- **`browserAction/style.css`** — removed the accent-colored `box-shadow` glow from `.btn-primary`; the button is now flat. Hover (`brightness`) and active (`translateY`) states are unchanged.
- **`manifest.json`** / **`package.json`** — version `0.11.1` -> `0.11.2`.

## Why
The glow around the Share button read as too heavy; a flat button fits the popup better.

## Notes for reviewer
- Version bump touches only these two files by design: `scripts/manifest.ts` copies the version into the Chrome/Firefox builds, and both popup + options footers read it at runtime via `browser.runtime.getManifest().version`. No other files needed editing (`git grep 0.11.1` is clean).
- Verified in a local static-server preview: computed `box-shadow` on `#shareLink` is now `none` in both light and dark schemes.